### PR TITLE
Upgrade the Setup.lhs file to work with new cabal

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -4,15 +4,18 @@
 module Main (main) where
 
 import Data.List ( nub )
-import Data.Version ( showVersion )
-import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
-import Distribution.Simple.BuildPaths ( autogenModulesDir )
-import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), fromFlag )
+import Distribution.Simple.BuildPaths ( autogenPackageModulesDir )
 import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
+import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), fromFlag )
+import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
+import Distribution.Types.MungedPackageId (MungedPackageId(..))
+import Distribution.Types.MungedPackageName (unMungedPackageName)
+import Distribution.Types.UnitId (UnitId)
+import Distribution.Types.UnqualComponentName (unUnqualComponentName)
 import Distribution.Verbosity ( Verbosity )
+import Distribution.Version ( showVersion )
 import System.FilePath ( (</>) )
 
 main :: IO ()
@@ -24,21 +27,22 @@ main = defaultMainWithHooks simpleUserHooks
 
 generateBuildModule :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
 generateBuildModule verbosity pkg lbi = do
-  let dir = autogenModulesDir lbi
+  let dir = autogenPackageModulesDir lbi
   createDirectoryIfMissingVerbose verbosity True dir
   withLibLBI pkg lbi $ \_ libcfg -> do
     withTestLBI pkg lbi $ \suite suitecfg -> do
-      rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
-        [ "module Build_" ++ testName suite ++ " where"
+      let testNameStr = unUnqualComponentName $ testName suite
+      rewriteFile (dir </> "Build_" ++ testNameStr ++ ".hs") $ unlines
+        [ "module Build_" ++ testNameStr ++ " where"
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]
   where
     formatdeps = map (formatone . snd)
-    formatone p = case packageName p of
-      PackageName n -> n ++ "-" ++ showVersion (packageVersion p)
+    formatone p =
+      unMungedPackageName (mungedName p) ++ "-" ++ showVersion (mungedVersion p)
 
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
+testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(UnitId, MungedPackageId)]
 testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys
 
 \end{code}


### PR DESCRIPTION
The setup script hasn't been updated since the Cabal 2.0 changes. This
commit replaces a few old constructs and deprecated functions with their
newer variants.

This addresses issue #9 